### PR TITLE
Add new tracking metrics (backend)

### DIFF
--- a/website/models/tracking.py
+++ b/website/models/tracking.py
@@ -11,6 +11,8 @@ class User(db.Model):
     career_goal = db.Column(db.String(100))
     career_stage = db.Column(db.String(100))
     priority = db.Column(db.String(100))
+    # Persisted once at onboarding submit for A/B analysis (short vs full)
+    onboarding_variant = db.Column(db.String(32))
     created_at = db.Column(db.DateTime, default=db.func.current_timestamp())
 
     # Relationship to see user actions and visits easily
@@ -31,6 +33,7 @@ class Action(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     atype = db.Column(db.String(200), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    detail = db.Column(db.JSON, nullable=True)
     timestamp = db.Column(db.DateTime, default=db.func.current_timestamp())
 
 class Feedback(db.Model):

--- a/website/static/js/custom.js
+++ b/website/static/js/custom.js
@@ -13,14 +13,17 @@ document.addEventListener('DOMContentLoaded', function() {
 /**
  * Sends a POST request to the Flask backend to log an action
  * @param {string} actionType - The 'atype' string saved in the DB
+ * @param {object|Array|undefined} detail - Optional JSON-serializable payload
  */
-function trackAction(actionType) {
+function trackAction(actionType, detail) {
+    var body = { atype: actionType };
+    if (detail != null) body.detail = detail;
     fetch("/track-action", { 
         method: "POST",
         headers: {
             "Content-Type": "application/json",
         },
-        body: JSON.stringify({ atype: actionType })
+        body: JSON.stringify(body)
     })
     .then(response => response.json())
     .then(data => console.log('Action tracked:', actionType))

--- a/website/static/js/roadmap-personalize.js
+++ b/website/static/js/roadmap-personalize.js
@@ -107,6 +107,9 @@
           li.appendChild(spacer);
         }
 
+        li.setAttribute("data-rm-section", key);
+        li.setAttribute("data-rm-label", item.text || "");
+
         ul.appendChild(li);
 
         var storageKey = item.text;

--- a/website/static/js/roadmap-tracking.js
+++ b/website/static/js/roadmap-tracking.js
@@ -1,0 +1,76 @@
+(function () {
+  var grid = document.getElementById("rmGrid");
+  if (!grid) return;
+
+  var started = Date.now();
+  var hasReportedRoadmapTime = false;
+
+  function postTrack(atype, detail) {
+    var body = { atype: atype };
+    if (detail != null) body.detail = detail;
+    fetch("/track-action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch(function () {});
+  }
+
+  function reportRoadmapTime() {
+    if (hasReportedRoadmapTime) return;
+    hasReportedRoadmapTime = true;
+    var sec = Math.min(7200, Math.round((Date.now() - started) / 1000));
+    var payload = JSON.stringify({
+      atype: "roadmap_time_on_page",
+      detail: { seconds: sec },
+    });
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(
+        "/track-action",
+        new Blob([payload], { type: "application/json" }),
+      );
+    } else {
+      fetch("/track-action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+        keepalive: true,
+      }).catch(function () {});
+    }
+  }
+
+  document.addEventListener(
+    "change",
+    function (e) {
+      var t = e.target;
+      if (!t || !t.classList || !t.classList.contains("program-checker"))
+        return;
+      var li = t.closest("li");
+      if (!li || !grid.contains(li)) return;
+      postTrack("roadmap_checkbox", {
+        section: li.getAttribute("data-rm-section") || "",
+        label: li.getAttribute("data-rm-label") || "",
+        checked: !!t.checked,
+      });
+    },
+    false,
+  );
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      var a = e.target.closest && e.target.closest("a");
+      if (!a || !a.href) return;
+      if (!grid.contains(a)) return;
+      postTrack("roadmap_link_click", {
+        href: a.href,
+        label: (a.textContent || "").trim(),
+      });
+    },
+    true,
+  );
+
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) reportRoadmapTime();
+  });
+  window.addEventListener("pagehide", reportRoadmapTime);
+})();

--- a/website/templates/majorSpecific/cs.html
+++ b/website/templates/majorSpecific/cs.html
@@ -121,6 +121,7 @@
     <script>window.__RM_MAJOR = "{{ major }}";</script>
     <script src="{{ url_for('static', filename='js/roadmap-personalize.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/popup.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/roadmap-tracking.js') }}" defer></script>
 
     {% include 'footer.html' %}
 </body>

--- a/website/templates/majorSpecific/econ.html
+++ b/website/templates/majorSpecific/econ.html
@@ -121,6 +121,7 @@
     <script>window.__RM_MAJOR = "{{ major }}";</script>
     <script src="{{ url_for('static', filename='js/roadmap-personalize.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/popup.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/roadmap-tracking.js') }}" defer></script>
 
     {% include 'footer.html' %}
 </body>

--- a/website/views/landing_views.py
+++ b/website/views/landing_views.py
@@ -31,14 +31,26 @@ def homepage():
 
 @landing_blueprint.route('/track-action', methods=['POST'])
 def track_action():
-    """Logs non-form actions like button clicks."""
-    data = request.get_json()
-    user_uuid = request.cookies.get('tracking_id')
-    
+    """Logs non-form actions (clicks, roadmap metrics, etc.)."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"status": "error", "message": "JSON body required"}), 400
+
+    atype = data.get("atype")
+    if not atype or not isinstance(atype, str):
+        return jsonify({"status": "error", "message": "atype required"}), 400
+    atype = atype.strip()[:200]
+
+    detail = data.get("detail")
+    if detail is not None and not isinstance(detail, (dict, list)):
+        return jsonify({"status": "error", "message": "detail must be an object or array"}), 400
+
+    user_uuid = request.cookies.get("tracking_id")
+
     if user_uuid:
         user = User.query.filter_by(uuid=user_uuid).first()
         if user:
-            new_action = Action(atype=data['atype'], user_id=user.id)
+            new_action = Action(atype=atype, user_id=user.id, detail=detail)
             db.session.add(new_action)
             db.session.commit()
     return jsonify({"status": "success"}), 200
@@ -115,6 +127,7 @@ def submit_info():
             user.career_goal = career_goal
             user.career_stage = career_stage
             user.priority = priority
+            user.onboarding_variant = "short" if variant == "short" else "full"
 
             core_action = Action(atype='roadmap_submit', user_id=user.id)
             db.session.add(core_action)


### PR DESCRIPTION
### Summary
Tracks roadmap behavior for the onboarding A/B test: which form someone got (short vs full), plus checkbox toggles, link clicks, and time on the roadmap page.

### Changes
- DB: `users.onboarding_variant`, `action.detail` (JSON) for extra fields on each event.
- API: `POST /track-action` accepts optional detail next to `atype`.
- Roadmap: New `roadmap-tracking.js` on CS/Econ pages; list rows get data-rm-* for stable labels.

### Event names
`roadmap_checkbox` · `roadmap_link_click` · `roadmap_time_on_page` (join to users.onboarding_variant for A/B).

You may need to delete your instance of the DB and restart app

